### PR TITLE
PositionTimer: making _lastValue thread-safe during an invocation (th…

### DIFF
--- a/HTFanControl/PositionTimer.cs
+++ b/HTFanControl/PositionTimer.cs
@@ -298,10 +298,6 @@ namespace Timers
                     _invoking = true;
                 }
             }
-            else
-            {
-                _lastValue = _defaultValue;
-            }
 
             _action?.Invoke(_lastValue);
 
@@ -363,6 +359,7 @@ namespace Timers
         {
             if (_timer == null)
             {
+                _lastValue = _defaultValue;
                 _invoking = true;
                 ThreadPool.QueueUserWorkItem(TimerCallback, null);
             }


### PR DESCRIPTION
…is is unfortunate: previously it purposely wasn't, but now because of the way TryGetNextPositions is using it, _lastValue does need to be thread-safe)