### PR TITLE
Move MQTT topics and payload into an extendable dictionary

### DIFF
--- a/HTFanControl/Controllers/MQTTController.cs
+++ b/HTFanControl/Controllers/MQTTController.cs
@@ -31,24 +31,8 @@ namespace HTFanControl.Controllers
                 Connect();
             }
 
-            string mqttTopic = cmd switch
-            {
-                "OFF" => _settings.MQTT_OFF_Topic,
-                "ECO" => _settings.MQTT_ECO_Topic,
-                "LOW" => _settings.MQTT_LOW_Topic,
-                "MED" => _settings.MQTT_MED_Topic,
-                "HIGH" => _settings.MQTT_HIGH_Topic,
-                _ => _settings.MQTT_OFF_Topic,
-            };
-            string mqttPayload = cmd switch
-            {
-                "OFF" => _settings.MQTT_OFF_Payload,
-                "ECO" => _settings.MQTT_ECO_Payload,
-                "LOW" => _settings.MQTT_LOW_Payload,
-                "MED" => _settings.MQTT_MED_Payload,
-                "HIGH" => _settings.MQTT_HIGH_Payload,
-                _ => _settings.MQTT_OFF_Payload,
-            };
+            string mqttTopic = _settings.MQTT_Topics[cmd] ?? _settings.MQTT_Topics["OFF"];
+            string mqttPayload = _settings.MQTT_Payloads[cmd] ?? _settings.MQTT_Payloads["OFF"];
 
             //case when using IR over MQTT and fan needs to be turned ON before a command can be sent
             if (_ONcmd && _isOFF)
@@ -58,15 +42,15 @@ namespace HTFanControl.Controllers
                     try
                     {
                         MqttApplicationMessage message = new MqttApplicationMessageBuilder()
-                            .WithTopic(_settings.MQTT_ON_Topic)
-                            .WithPayload(_settings.MQTT_ON_Payload)
+                            .WithTopic(_settings.MQTT_Topics["ON"])
+                            .WithPayload(_settings.MQTT_Payloads["ON"])
                             .Build();
 
                         _mqttClient.PublishAsync(message);
                     }
                     catch
                     {
-                        ErrorStatus = @$"({DateTime.Now:h:mm:ss tt}) Failed turning fan ON by sending Topic: ""{_settings.MQTT_ON_Topic}"" and Payload: ""{_settings.MQTT_ON_Payload}"" To: {_settings.MQTT_IP}:{_settings.MQTT_Port}";
+                        ErrorStatus = @$"({DateTime.Now:h:mm:ss tt}) Failed turning fan ON by sending Topic: ""{_settings.MQTT_Topics["ON"]}"" and Payload: ""{_settings.MQTT_Payloads["ON"]}"" To: {_settings.MQTT_IP}:{_settings.MQTT_Port}";
                         return false;
                     }
 

--- a/HTFanControl/Main/WebUI.cs
+++ b/HTFanControl/Main/WebUI.cs
@@ -380,18 +380,18 @@ namespace HTFanControl.Main
             html = html.Replace("{MqttUser}", _HTFanCtrl._settings.MQTT_User);
             html = html.Replace("{MqttPass}", _HTFanCtrl._settings.MQTT_Pass);
 
-            html = html.Replace("{MqttOFFtopic}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_OFF_Topic));
-            html = html.Replace("{MqttOFFpayload}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_OFF_Payload));
-            html = html.Replace("{MqttECOtopic}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_ECO_Topic));
-            html = html.Replace("{MqttECOpayload}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_ECO_Payload));
-            html = html.Replace("{MqttLOWtopic}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_LOW_Topic));
-            html = html.Replace("{MqttLOWpayload}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_LOW_Payload));
-            html = html.Replace("{MqttMEDtopic}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_MED_Topic));
-            html = html.Replace("{MqttMEDpayload}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_MED_Payload));
-            html = html.Replace("{MqttHIGHtopic}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_HIGH_Topic));
-            html = html.Replace("{MqttHIGHpayload}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_HIGH_Payload));
-            html = html.Replace("{MqttONtopic}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_ON_Topic));
-            html = html.Replace("{MqttONpayload}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_ON_Payload));
+            html = html.Replace("{MqttOFFtopic}", _HTFanCtrl._settings.MQTT_Topics.ContainsKey("OFF") ? _HTFanCtrl._settings.MQTT_Topics["OFF"] : "");
+            html = html.Replace("{MqttOFFpayload}", _HTFanCtrl._settings.MQTT_Payloads.ContainsKey("OFF") ? _HTFanCtrl._settings.MQTT_Payloads["OFF"] : "");
+            html = html.Replace("{MqttECOtopic}", _HTFanCtrl._settings.MQTT_Topics.ContainsKey("ECO") ? _HTFanCtrl._settings.MQTT_Topics["ECO"] : "");
+            html = html.Replace("{MqttECOpayload}", _HTFanCtrl._settings.MQTT_Payloads.ContainsKey("ECO") ? _HTFanCtrl._settings.MQTT_Payloads["ECO"] : "");
+            html = html.Replace("{MqttLOWtopic}", _HTFanCtrl._settings.MQTT_Topics.ContainsKey("LOW") ? _HTFanCtrl._settings.MQTT_Topics["LOW"] : "");
+            html = html.Replace("{MqttLOWpayload}", _HTFanCtrl._settings.MQTT_Payloads.ContainsKey("LOW") ? _HTFanCtrl._settings.MQTT_Payloads["LOW"] : "");
+            html = html.Replace("{MqttMEDtopic}", _HTFanCtrl._settings.MQTT_Topics.ContainsKey("MED") ? _HTFanCtrl._settings.MQTT_Topics["MED"] : "");
+            html = html.Replace("{MqttMEDpayload}", _HTFanCtrl._settings.MQTT_Payloads.ContainsKey("MED") ? _HTFanCtrl._settings.MQTT_Payloads["MED"] : "");
+            html = html.Replace("{MqttHIGHtopic}", _HTFanCtrl._settings.MQTT_Topics.ContainsKey("HIGH") ? _HTFanCtrl._settings.MQTT_Topics["HIGH"] : "");
+            html = html.Replace("{MqttHIGHpayload}", _HTFanCtrl._settings.MQTT_Payloads.ContainsKey("HIGH") ? _HTFanCtrl._settings.MQTT_Payloads["HIGH"] : "");
+            html = html.Replace("{MqttONtopic}", _HTFanCtrl._settings.MQTT_Topics.ContainsKey("ON") ? _HTFanCtrl._settings.MQTT_Topics["ON"] : "");
+            html = html.Replace("{MqttONpayload}", _HTFanCtrl._settings.MQTT_Payloads.ContainsKey("ON") ? _HTFanCtrl._settings.MQTT_Payloads["ON"] : "");
             html = html.Replace("{MqttONdelay}", HttpUtility.HtmlEncode(_HTFanCtrl._settings.MQTT_ON_Delay));
 
             if (_HTFanCtrl._settings.MediaPlayerType == "MPC")
@@ -478,18 +478,19 @@ namespace HTFanControl.Main
                 _HTFanCtrl._settings.MQTT_Port = int.TryParse(data.RootElement.GetProperty("MqttPort").GetString(), out int MqttPort) ? MqttPort : 1883;
                 _HTFanCtrl._settings.MQTT_User = data.RootElement.GetProperty("MqttUser").GetString();
                 _HTFanCtrl._settings.MQTT_Pass = data.RootElement.GetProperty("MqttPass").GetString();
-                _HTFanCtrl._settings.MQTT_OFF_Topic = data.RootElement.GetProperty("MqttOFFtopic").GetString();
-                _HTFanCtrl._settings.MQTT_OFF_Payload = data.RootElement.GetProperty("MqttOFFpayload").GetString();
-                _HTFanCtrl._settings.MQTT_ECO_Topic = data.RootElement.GetProperty("MqttECOtopic").GetString();
-                _HTFanCtrl._settings.MQTT_ECO_Payload = data.RootElement.GetProperty("MqttECOpayload").GetString();
-                _HTFanCtrl._settings.MQTT_LOW_Topic = data.RootElement.GetProperty("MqttLOWtopic").GetString();
-                _HTFanCtrl._settings.MQTT_LOW_Payload = data.RootElement.GetProperty("MqttLOWpayload").GetString();
-                _HTFanCtrl._settings.MQTT_MED_Topic = data.RootElement.GetProperty("MqttMEDtopic").GetString();
-                _HTFanCtrl._settings.MQTT_MED_Payload = data.RootElement.GetProperty("MqttMEDpayload").GetString();
-                _HTFanCtrl._settings.MQTT_HIGH_Topic = data.RootElement.GetProperty("MqttHIGHtopic").GetString();
-                _HTFanCtrl._settings.MQTT_HIGH_Payload = data.RootElement.GetProperty("MqttHIGHpayload").GetString();
-                _HTFanCtrl._settings.MQTT_ON_Topic = data.RootElement.GetProperty("MqttONtopic").GetString();
-                _HTFanCtrl._settings.MQTT_ON_Payload = data.RootElement.GetProperty("MqttONpayload").GetString();
+                _HTFanCtrl._settings.MQTT_Topics.Add("OFF", data.RootElement.GetProperty("MqttOFFtopic").GetString());
+                _HTFanCtrl._settings.MQTT_Topics.Add("ON", data.RootElement.GetProperty("MqttONtopic").GetString());
+                _HTFanCtrl._settings.MQTT_Topics.Add("ECO", data.RootElement.GetProperty("MqttECOtopic").GetString());
+                _HTFanCtrl._settings.MQTT_Topics.Add("LOW", data.RootElement.GetProperty("MqttLOWtopic").GetString());
+                _HTFanCtrl._settings.MQTT_Topics.Add("MED", data.RootElement.GetProperty("MqttMEDtopic").GetString());
+                _HTFanCtrl._settings.MQTT_Topics.Add("HIGH", data.RootElement.GetProperty("MqttHIGHtopic").GetString());
+                _HTFanCtrl._settings.MQTT_Payloads.Add("OFF", data.RootElement.GetProperty("MqttOFFpayload").GetString());
+                _HTFanCtrl._settings.MQTT_Payloads.Add("ON", data.RootElement.GetProperty("MqttONpayload").GetString());
+                _HTFanCtrl._settings.MQTT_Payloads.Add("ECO", data.RootElement.GetProperty("MqttECOpayload").GetString());
+                _HTFanCtrl._settings.MQTT_Payloads.Add("LOW", data.RootElement.GetProperty("MqttLOWpayload").GetString());
+                _HTFanCtrl._settings.MQTT_Payloads.Add("MED", data.RootElement.GetProperty("MqttMEDpayload").GetString());
+                _HTFanCtrl._settings.MQTT_Payloads.Add("HIGH", data.RootElement.GetProperty("MqttHIGHpayload").GetString());
+
                 _HTFanCtrl._settings.MQTT_ON_Delay = int.TryParse(data.RootElement.GetProperty("MqttONdelay").GetString(), out int MqttONdelay) ? MqttONdelay: 0;
                 _HTFanCtrl._settings.MediaPlayerIP = data.RootElement.GetProperty("MediaPlayerIP").GetString();
                 _HTFanCtrl._settings.MediaPlayerPort = int.TryParse(data.RootElement.GetProperty("MediaPlayerPort").GetString(), out int MediaPlayerPort) ? MediaPlayerPort : 0;

--- a/HTFanControl/Util/Settings.cs
+++ b/HTFanControl/Util/Settings.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Collections.Generic;
 
 namespace HTFanControl.Util
 {
@@ -19,18 +20,8 @@ namespace HTFanControl.Util
         public int MQTT_Port { get; set; }
         public string MQTT_User { get; set; }
         public string MQTT_Pass { get; set; }
-        public string MQTT_OFF_Topic { get; set; }
-        public string MQTT_OFF_Payload { get; set; }
-        public string MQTT_ECO_Topic { get; set; }
-        public string MQTT_ECO_Payload { get; set; }
-        public string MQTT_LOW_Topic { get; set; }
-        public string MQTT_LOW_Payload { get; set; }
-        public string MQTT_MED_Topic { get; set; }
-        public string MQTT_MED_Payload { get; set; }
-        public string MQTT_HIGH_Topic { get; set; }
-        public string MQTT_HIGH_Payload { get; set; }
-        public string MQTT_ON_Topic { get; set; }
-        public string MQTT_ON_Payload { get; set; }
+        public Dictionary<string,string> MQTT_Topics { get; set; }
+        public Dictionary<string,string> MQTT_Payloads { get; set; }
         public int MQTT_ON_Delay { get; set; }
         public string AudioDevice { get; set; }
         public string PlexToken { get; set; }
@@ -65,16 +56,18 @@ namespace HTFanControl.Util
                 settings.MediaPlayerPort = 8080;
                 settings.ControllerType = "MQTT";
                 settings.MQTT_IP = "127.0.0.1";
-                settings.MQTT_OFF_Topic = "cmnd/HTFan/EVENT";
-                settings.MQTT_OFF_Payload = "s0";
-                settings.MQTT_ECO_Topic = "cmnd/HTFan/EVENT";
-                settings.MQTT_ECO_Payload = "s1";
-                settings.MQTT_LOW_Topic = "cmnd/HTFan/EVENT";
-                settings.MQTT_LOW_Payload = "s2";
-                settings.MQTT_MED_Topic = "cmnd/HTFan/EVENT";
-                settings.MQTT_MED_Payload = "s3";
-                settings.MQTT_HIGH_Topic = "cmnd/HTFan/EVENT";
-                settings.MQTT_HIGH_Payload = "s4";
+                settings.MQTT_Topics = new Dictionary<string, string>();
+                settings.MQTT_Topics.Add("OFF", "cmnd/HTFan/EVENT");
+                settings.MQTT_Topics.Add("ECO", "cmnd/HTFan/EVENT");
+                settings.MQTT_Topics.Add("LOW", "cmnd/HTFan/EVENT");
+                settings.MQTT_Topics.Add("MED", "cmnd/HTFan/EVENT");
+                settings.MQTT_Topics.Add("HIGH", "cmnd/HTFan/EVENT");
+                settings.MQTT_Payloads = new Dictionary<string, string>();
+                settings.MQTT_Payloads.Add("OFF", "s0");
+                settings.MQTT_Payloads.Add("ECO", "s1");
+                settings.MQTT_Payloads.Add("LOW", "s2");
+                settings.MQTT_Payloads.Add("MED", "s3");
+                settings.MQTT_Payloads.Add("HIGH", "s4");
                 settings.GlobalOffsetMS = 2000;
                 settings.ECOSpinupOffsetMS = 1400;
                 settings.LOWSpinupOffsetMS = 1200;


### PR DESCRIPTION
This change moves all the MQTT topics and payloads into a dictionary, so that additional commands can be configured in the settings JSON file